### PR TITLE
Fix ClassNotFoundException in RustReferenceContributor 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.github.amondeshir.rustroverjronremix
 pluginName = RON Extended Support for Rust Rover
 pluginRepositoryUrl = https://github.com/AmonDeShir/rustrover-ron-remix/
-pluginVersion = 0.3.5
+pluginVersion = 0.3.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 252.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # IntelliJ Platform Artifacts Repositories
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
-pluginGroup = com.github.amondeshir.rustroverjronremix
+pluginGroup = com.github.amondeshir.rustroverronremix
 pluginName = RON Extended Support for Rust Rover
 pluginRepositoryUrl = https://github.com/AmonDeShir/rustrover-ron-remix/
-pluginVersion = 0.3.6
+pluginVersion = 0.3.5
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 252.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@
 pluginGroup = com.github.amondeshir.rustroverronremix
 pluginName = RON Extended Support for Rust Rover
 pluginRepositoryUrl = https://github.com/AmonDeShir/rustrover-ron-remix/
-pluginVersion = 0.3.5
+pluginVersion = 0.3.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 252.0
-pluginUntilBuild = 252.*
+pluginSinceBuild = 253.0
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = RR
-platformVersion = 2025.2
+platformVersion = 2025.3
 
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/resources/META-INF/com.github.amondeshir.rustroverronremix-rust.xml
+++ b/src/main/resources/META-INF/com.github.amondeshir.rustroverronremix-rust.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <psi.referenceContributor implementation="com.github.amondeshir.rustroverjronremix.rust.RustReferenceContributor" language="RON"/>
+        <psi.referenceContributor implementation="com.github.amondeshir.rustroverronremix.rust.RustReferenceContributor" language="RON"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Should close #1. Fixes the ClassNotFoundException in RustReferenceContributor and bumps the plugin version to 0.3.6.